### PR TITLE
added pi pico rp2040. added option to use ws2812 as led layer indicators

### DIFF
--- a/keyboards/handwired/replicazeron/common/thumbstick.c
+++ b/keyboards/handwired/replicazeron/common/thumbstick.c
@@ -70,7 +70,7 @@ void thumbstick(controller_state_t controller_state) {
     // Update WASD state depending on thumbstick position
     // if thumbstick out of of deadzone
     if (thumbstick_polar_position.distance >= _DEADZONE) {
-        wasd_state.w = update_keystate(  0,  90, thumbstick_polar_position.angle);
+        wasd_state.w = update_keystate(  -1,  90, thumbstick_polar_position.angle);
         // A angle:  45 - 180
         wasd_state.a = update_keystate( 45, 181, thumbstick_polar_position.angle);
         // S angle: 135 - 270

--- a/keyboards/handwired/replicazeron/common/thumbstick.c
+++ b/keyboards/handwired/replicazeron/common/thumbstick.c
@@ -46,7 +46,7 @@ thumbstick_polar_position_t get_thumbstick_polar_position(int16_t x, int16_t y) 
 }
 
 bool update_keystate(uint16_t angle_from, uint16_t angle_to, uint16_t angle) {
-    return (angle_from < angle && angle <= angle_to);
+    return (angle_from <= angle && angle <= angle_to);
 }
 
 void update_keycode(uint16_t keycode, bool keystate, bool last_keystate) {
@@ -70,7 +70,7 @@ void thumbstick(controller_state_t controller_state) {
     // Update WASD state depending on thumbstick position
     // if thumbstick out of of deadzone
     if (thumbstick_polar_position.distance >= _DEADZONE) {
-        wasd_state.w = update_keystate(  -1,  90, thumbstick_polar_position.angle);
+        wasd_state.w = update_keystate(  0,  90, thumbstick_polar_position.angle);
         // A angle:  45 - 180
         wasd_state.a = update_keystate( 45, 181, thumbstick_polar_position.angle);
         // S angle: 135 - 270

--- a/keyboards/handwired/replicazeron/config.h
+++ b/keyboards/handwired/replicazeron/config.h
@@ -18,6 +18,12 @@
 
 #define THUMBSTICK_DEBUG
 
+/* rgb indicadors*/
+#define RGBINDICATORS
+#define RGBLIGHT_LAYERS
+#define RGBLIGHT_LAYERS_RETAIN_VAL
+#define RGBLIGHT_LAYERS_OVERRIDE_RGB_OFF
+
 /* joystick configuration */
 #define JOYSTICK_BUTTON_COUNT 0
 #define JOYSTICK_AXIS_COUNT 2

--- a/keyboards/handwired/replicazeron/readme.md
+++ b/keyboards/handwired/replicazeron/readme.md
@@ -33,44 +33,44 @@ Full schematics can be found in this repo:
 https://github.com/9R/replicazeron_schematics
 
 ### Rows
-|row| promiro gpios | promicro pin | stm32F103 gpios |   color |
-|---|---------------|--------------|-----------------|---------|
-| 0 |          B1   |          15  |          B15    |  red    |
-| 1 |          B3   |          14  |           A8    |  blue   |
-| 2 |          B2   |          16  |           A9    |  yellow |
-| 3 |          B6   |          10  |          A10    |  brown  |
-| 4 |          B5   |           9  |          A15    |  orange |
-| 5 |          B4   |           8  |           B3    |  green  |
+|row| promiro gpios | promicro pin | stm32F103 gpios | pi pico rp2040 gpios |   color |
+|---|---------------|--------------|-----------------|----------------------|---------|
+| 0 |          B1   |          15  |          B15    |            GPIO16    |  red    |
+| 1 |          B3   |          14  |           A8    |            GPIO17    |  blue   |
+| 2 |          B2   |          16  |           A9    |            GPIO18    |  yellow |
+| 3 |          B6   |          10  |          A10    |            GPIO19    |  brown  |
+| 4 |          B5   |           9  |          A15    |            GPIO20    |  orange |
+| 5 |          B4   |           8  |           B3    |            GPIO21    |  green  |
 
 ### Columns
-|col| promiro gpios | promicro pin | stm32F103 gpios |  color  |
-|---|---------------|--------------|-----------------|---------|
-| 0 |         C6    |            5 |          A7     |  white  |
-| 1 |         D4    |            4 |          A6     |  grey   |
-| 2 |         D7    |            6 |          A5     |  violet |
-| 3 |         E6    |            7 |          A4     |  grey   |
-| 4 |         F7    |           A0 |          B4     |  white  |
+|col| promiro gpios | promicro pin | stm32F103 gpios | pi pico rp2040 gpios |  color  |
+|---|---------------|--------------|-----------------|----------------------|---------|
+| 0 |         C6    |            5 |          A7     |            GPIO10    |  white  |
+| 1 |         D4    |            4 |          A6     |            GPIO11    |  grey   |
+| 2 |         D7    |            6 |          A5     |            GPIO12    |  violet |
+| 3 |         E6    |            7 |          A4     |            GPIO13    |  grey   |
+| 4 |         F7    |           A0 |          B4     |            GPIO14    |  white  |
 
 ### Analog
-| promicro gpio | stm32F103 gpio | pin | color |
-|---------------|----------------|-----|-------|
-|          GND  |           GND  | GND | white |
-|          VCC  |           VCC  | VCC | red   |
-|          F4   |           B1   | VRx | brown |
-|          F5   |           B0   | VRy | yellow|
-|               |                | SW  | blue  |
+| promicro gpio | stm32F103 gpio | pi pico rp2040 gpios | pin | color |
+|---------------|----------------|----------------------|-----|-------|
+|          GND  |           GND  |        GND           | GND | white |
+|          VCC  |           VCC  |        VCC (3.3v)    | VCC | red   |
+|          F4   |           B1   |        GPIO27        | VRx | brown |
+|          F5   |           B0   |        GPIO28        | VRy | yellow|
+|               |                |                      | SW  | blue  |
 
 ### OLED
-| promicro gpio | stm32F103 gpio | pin | color |
-|---------------|----------------|-----|-------|
-|          GND  |           GND  | GND | white |
-|          VCC  |           VCC  | VCC | red   |
-|           D4  |           B10  | SDA | green |
-|           C6  |           B11  | SCL | yellow|
+| promicro gpio | stm32F103 gpio | pi pico rp2040 gpios | pin | color |
+|---------------|----------------|----------------------|-----|-------|
+|          GND  |           GND  |        GND           | GND | white |
+|          VCC  |           VCC  |        VCC (3.3v)    | VCC | red   |
+|           D4  |           B10  |        GPIO0         | SDA | green |
+|           C6  |           B11  |        GPIO1         | SCL | yellow|
 
 ### LIGHTING
-| promicro gpio | stm32F103 gpio | pin  | LED    |
-|---------------|----------------|------|--------|
-|           D2  |           B13  | GND  | LED0   |
-|           D3  |           B12  | VCC  | LED1   |
-|               |           B14  | Data | WS2812 |
+| promicro gpio | stm32F103 gpio | pi pico rp2040 gpios | pin  | LED    |
+|---------------|----------------|----------------------|------|--------|
+|           D2  |           B13  |        GPIO2         | GND  | LED0   |
+|           D3  |           B12  |        GPIO3         | VCC  | LED1   |
+|               |           B14  |        GPIO4         | Data | WS2812 |

--- a/keyboards/handwired/replicazeron/replicazeron.c
+++ b/keyboards/handwired/replicazeron/replicazeron.c
@@ -15,6 +15,7 @@
  */
 
 #include "replicazeron.h"
+#include "analog.h"
 
 controller_state_t controller_state;
 
@@ -32,6 +33,57 @@ void housekeeping_task_kb(void) {
     }
 }
 #endif
+#ifdef RGBINDICATORS
+// Define layers
+const rgblight_segment_t PROGMEM my_capslock_layer[] = RGBLIGHT_LAYER_SEGMENTS(
+    {0, 2, HSV_RED}       // Light 1 LEDs, starting with LED 0
+);
+
+// Light LEDs 9 & 10 in cyan when keyboard layer 1 is active
+const rgblight_segment_t PROGMEM layer0[] = RGBLIGHT_LAYER_SEGMENTS(
+    {0, 1, HSV_CYAN}
+);
+// Light LEDs 11 & 12 in purple when keyboard layer 2 is active
+const rgblight_segment_t PROGMEM layer1[] = RGBLIGHT_LAYER_SEGMENTS(
+    {1, 1, HSV_PURPLE}
+);
+//etc.... end def layers
+
+// Now define the array of layers. Later layers take precedence
+const rgblight_segment_t* const PROGMEM my_rgb_layers[] = RGBLIGHT_LAYERS_LIST(
+    my_capslock_layer,
+    layer0,
+    layer1
+    //my_layer1_layer,    // Overrides caps lock layer
+    //my_layer2_layer,    // Overrides other layers
+    //my_layer3_layer     // Overrides other layers
+);
+
+void keyboard_post_init_user(void) {
+    // Enable the LED layers
+    rgblight_layers = my_rgb_layers;
+}
+
+//enabling and disabling
+bool led_update_user(led_t led_state) {
+    rgblight_set_layer_state(0, led_state.caps_lock);
+    return true;
+}
+
+void set_wsleds(uint8_t highest_active_layer) {
+    if (highest_active_layer > 3) {
+        rgblight_set_layer_state(1, false);
+        rgblight_set_layer_state(2, false);
+        return;
+    }
+
+    // use bitwise operations to display active layer in binary
+    bool bit1 = (highest_active_layer & 1);
+    bool bit2 = (highest_active_layer & 2);
+    rgblight_set_layer_state(1, bit1);
+    rgblight_set_layer_state(2, bit2);
+}
+#endif //RGBINDICATORS
 
 void keyboard_post_init_kb(void) {
     // Customise these values to desired behaviour
@@ -62,13 +114,16 @@ bool oled_task_kb(void) {
     draw_oled(controller_state);
     return false;
 }
+
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    return OLED_ROTATION_180;
+}
 #endif
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     if (!process_record_user(keycode, record)) {
         return false;
     }
-
 
     if (keycode == JOYMODE && record->event.pressed) {
       if (!controller_state.wasdMode) {
@@ -98,6 +153,10 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
 #ifdef LEDS_ENABLE
     set_leds(controller_state.highestActiveLayer) ;
 #endif // LEDS_ENABLE
+
+#ifdef RGBINDICATORS
+    set_wsleds(controller_state.highestActiveLayer) ;
+#endif //RGBINDICATORS
 
     return state;
 }

--- a/keyboards/handwired/replicazeron/rp2040/config.h
+++ b/keyboards/handwired/replicazeron/rp2040/config.h
@@ -1,0 +1,35 @@
+/* Copyright 2023 9R
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET // Activates the double-tap behavior
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 200U // Timeout window in ms in which the double tap can occur.
+#define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP25 // Specify a optional status led by GPIO number which blinks when entering the bootloader
+
+#define FORCE_NKRO
+
+/* I2C Config */
+#define I2C_DRIVER I2CD1
+#define I2C1_SDA_PIN GP2
+#define I2C1_SCL_PIN GP3
+
+#define STATUS_LED_A_PIN B13
+#define STATUS_LED_B_PIN B12
+
+#define JOYSTICK_DEBUG
+#define ANALOG_AXIS_PIN_X GP27
+#define ANALOG_AXIS_PIN_Y GP28

--- a/keyboards/handwired/replicazeron/rp2040/halconf.h
+++ b/keyboards/handwired/replicazeron/rp2040/halconf.h
@@ -1,0 +1,8 @@
+// Copyright 2022 Stefan Kerkmann
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define HAL_USE_I2C TRUE
+
+#include_next <halconf.h>

--- a/keyboards/handwired/replicazeron/rp2040/keyboard.json
+++ b/keyboards/handwired/replicazeron/rp2040/keyboard.json
@@ -1,0 +1,33 @@
+{   
+    "keyboard_name": "Replicazeron",
+    "processor": "RP2040",
+    "bootloader": "rp2040", 
+    "features": {
+        "bootmagic": true,
+        "console": true,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true,
+        "rgblight": true
+    },
+    "matrix_pins": {
+        "cols": ["GP10", "GP11", "GP12", "GP13","GP14"],
+        "rows": ["GP16", "GP17", "GP18", "GP19", "GP20", "GP21"]
+    },
+    "rgblight": {
+        "led_count": 8
+        "animations": {
+            "breathing": true,
+            "knight": true,
+            "rainbow_mood": true,
+            "rainbow_swirl": true,
+            "twinkle": true
+        }
+    },
+    "usb": {
+        "device_version": "0.0.3"
+    },
+    "ws2812": {
+        "pin": "GP4"
+    }
+}

--- a/keyboards/handwired/replicazeron/rp2040/mcuconf.h
+++ b/keyboards/handwired/replicazeron/rp2040/mcuconf.h
@@ -1,0 +1,23 @@
+/* Copyright 2022 9R 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include_next <mcuconf.h>
+
+//enable i2c for OLED
+#undef RP_I2C_USE_I2C0
+#define RP_I2C_USE_I2C0 TRUE

--- a/keyboards/handwired/replicazeron/rules.mk
+++ b/keyboards/handwired/replicazeron/rules.mk
@@ -11,4 +11,9 @@ SRC += state.c
 VPATH += keyboards/handwired/replicazeron/common
 
 # redirect compilation against "handwired/replicazeron" to the stm32 variant
-DEFAULT_FOLDER = handwired/replicazeron/stm32f103
+#DEFAULT_FOLDER = handwired/replicazeron/stm32f103
+DEFAULT_FOLDER = handwired/replicazeron/rp2040
+
+# add below lines for rp2040
+WS2812_DRIVER = vendor
+ANALOG_DRIVER_REQUIRED = yes

--- a/keyboards/handwired/replicazeron/rules.mk
+++ b/keyboards/handwired/replicazeron/rules.mk
@@ -17,3 +17,6 @@ DEFAULT_FOLDER = handwired/replicazeron/rp2040
 # add below lines for rp2040
 WS2812_DRIVER = vendor
 ANALOG_DRIVER_REQUIRED = yes
+
+# rgd indicator
+RGBINDICATORS = yes


### PR DESCRIPTION
add pi pico rp2040 support.
updated the readme with the rp2040 pin out.

added option to use ws2812 led strip as indicator lights.

Possible issues: firmware size may exceed the limit for the stm32.

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [ ] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
